### PR TITLE
chore: add license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Library to reconcile JSON patch changes using Operational Transformation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/ThreadsStyling/json-patch-ot/blob/master/LICENSE"
+    }
+  ],
   "files": [
     "lib/"
   ],

--- a/package.json
+++ b/package.json
@@ -4,12 +4,7 @@
   "description": "Library to reconcile JSON patch changes using Operational Transformation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/ThreadsStyling/json-patch-ot/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "files": [
     "lib/"
   ],
@@ -43,7 +38,6 @@
     "transformation"
   ],
   "author": "jasoniangreen@gmail.com",
-  "license": "ISC",
   "bugs": {
     "url": "https://github.com/ThreadsStyling/json-patch-ot/issues"
   },


### PR DESCRIPTION
NPM page picks up the wrong license so I assume we have to put it into the package.json too.