### PR TITLE
feat: redirect on move option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ const result = JSONPatchOT(acceptedOps, proposedOps, options); // options passed
 //   // {op: OpType.replace, path: '/toreplace', value: 'something else'}, <- removed
 // ]
 ```
+
+> `redirectOnMove`
+
+By default accepted move operations cancel proposed operations that are targeting elements within their `from` path. In the example below, without the option passed, the proposed replace operation would be discarded. By using `redirectOnMove` the proposed operation will be kept and applied to the moved element on its new path instead.
+```js
+import jsonPatchOT, { Operation } from "@threads/json-patch-ot";
+
+const options = {redirectOnMove: true};
+const acceptedOps: Operation[] = [{op: OpType.move, from: '/frompath', path: '/topath'}];
+const proposedOps: Operation[] = [{op: OpType.replace, path: '/frompath', value: 10}];
+
+const result = JSONPatchOT(acceptedOps, proposedOps, options); // options passed here
+
+// result = [
+//   {op: OpType.replace, path: '/topath', value: 10},
+// ]
+```
 <!-- prettier-ignore-end -->
 
 ## Acknowledgements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@salsita/json-patch-ot",
-  "version": "1.1.1",
+  "name": "@threads/json-patch-ot",
+  "version": "1.1.0",
   "description": "Library to reconcile JSON patch changes using Operational Transformation",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {isValidIndex, replacePathIndices} from './utils';
 
 export interface Options {
   acceptedWinsOnEqualPath?: boolean;
+  redirectOnMove?: boolean;
 }
 
 export enum OpType {
@@ -208,12 +209,16 @@ const copyTransformer = (acceptedOp: OperationCopy, proposedOps: Operation[], op
 };
 
 const moveTransformer = (acceptedOp: OperationMove, proposedOps: Operation[], options: Options): void => {
-  redirectPaths(acceptedOp, proposedOps);
+  if (options.redirectOnMove) {
+    redirectPaths(acceptedOp, proposedOps);
+  }
   removeOperations(acceptedOp, proposedOps, {acceptedWinsOnEqualPath: true}, true, 'from'); // like a remove
   shiftIndices(acceptedOp, proposedOps, false, 'from'); // like a remove
   shiftIndices(acceptedOp, proposedOps, true, 'path'); // like an add
   removeOperations(acceptedOp, proposedOps, options, false, 'path'); // like an add
-  removeRedirectedFlag(proposedOps);
+  if (options.redirectOnMove) {
+    removeRedirectedFlag(proposedOps);
+  }
 };
 
 const transformAgainst = {


### PR DESCRIPTION
- added option to allow transforming paths of operations against move operations to their destinations instead of discarding them as described in #9
- added unit tests to cover the new option and a couple of cases that haven't been covered before
- updated readme with the new option